### PR TITLE
Protege acciones del carrito con POST y CSRF

### DIFF
--- a/carrito/templates/carrito/carrito.html
+++ b/carrito/templates/carrito/carrito.html
@@ -28,14 +28,23 @@
             <td class="text-center">{{ item.precio|moneda }}</td>
             <td class="text-center">
               <div class="d-inline-flex align-items-center gap-2">
-                <a href="{% url 'carrito:restar_producto' item.producto_id %}" class="btn btn-sm btn-outline-secondary">-</a>
+                <form method="post" action="{% url 'carrito:restar_producto' item.producto_id %}" class="d-inline">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-sm btn-outline-secondary">-</button>
+                </form>
                 <span class="mx-1 fw-semibold">{{ item.cantidad }}</span>
-                <a href="{% url 'carrito:agregar_al_carrito' item.producto_id %}" class="btn btn-sm btn-outline-secondary">+</a>
+                <form method="post" action="{% url 'carrito:agregar_al_carrito' item.producto_id %}" class="d-inline">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-sm btn-outline-secondary">+</button>
+                </form>
               </div>
             </td>
             <td class="text-end">{{ item.cantidad|multiply:item.precio|moneda }}</td>
             <td class="text-center">
-              <a href="{% url 'carrito:eliminar_producto' key %}" class="btn btn-sm btn-danger">🗑️</a>
+              <form method="post" action="{% url 'carrito:eliminar_producto' key %}" class="d-inline">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+              </form>
             </td>
           </tr>
           {% endfor %}
@@ -52,9 +61,12 @@
 
     <div class="d-flex flex-wrap gap-2 justify-content-end mt-3">
       <a href="{% url 'tienda:tienda' %}" class="btn btn-outline-secondary">Seguir Ordenando</a>
-      <button type="button" id="btnVaciar" class="btn btn-outline-danger">
-  Vaciar Carrito
-</button>
+      <form method="post" action="{% url 'carrito:limpiar_carrito' %}" id="formVaciar" class="d-inline">
+        {% csrf_token %}
+        <button type="submit" id="btnVaciar" class="btn btn-outline-danger">
+          Vaciar Carrito
+        </button>
+      </form>
       <a href="{% url 'carrito:checkout' %}" class="btn text-white" style="background-color:#ff8c42;">Realizar pedido</a>
     </div>
 
@@ -66,9 +78,17 @@
   {% endif %}
 </section>
 <script>
-document.getElementById("btnVaciar").addEventListener("click", async () => {
-  const res = await fetch("{% url 'carrito:limpiar_carrito' %}", {
-    headers: {'X-Requested-With': 'XMLHttpRequest'}
+document.getElementById("formVaciar")?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+
+  const form = event.currentTarget;
+  const res = await fetch(form.action, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRFToken": window.DulceCayena.getCsrfToken()
+    }
   });
 
   // ✅ Si vacío correctamente → mostrar vista carrito vacío sin salir del carrito

--- a/carrito/templates/carrito/checkout.html
+++ b/carrito/templates/carrito/checkout.html
@@ -76,7 +76,10 @@
           </div>
 
           <div class="d-flex flex-wrap gap-2 justify-content-between">
-            <a href="{% url 'carrito:limpiar_carrito' %}" class="btn btn-outline-danger">Vaciar Carrito</a>
+            <form method="post" action="{% url 'carrito:limpiar_carrito' %}" id="formVaciarCheckout" class="d-inline">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-outline-danger">Vaciar Carrito</button>
+            </form>
 
             <a href="{% url 'tienda:tienda' %}" class="btn btn-outline-secondary">Seguir Ordenando</a>
 
@@ -179,16 +182,19 @@
 
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-  const btnVaciar = document.querySelector(".btn-outline-danger[href*='limpiar']");
-  if (!btnVaciar) return;
+  const formVaciar = document.getElementById("formVaciarCheckout");
+  if (!formVaciar) return;
 
-  btnVaciar.addEventListener("click", function(e) {
+  formVaciar.addEventListener("submit", function(e) {
     e.preventDefault();
-    const url = this.getAttribute("href");
 
-    fetch(url, {
-      method: "GET",
-      headers: { "X-Requested-With": "XMLHttpRequest" }
+    fetch(formVaciar.action, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "X-CSRFToken": window.DulceCayena.getCsrfToken()
+      }
     })
     .then(res => res.json())
     .then(data => {
@@ -209,7 +215,7 @@ document.addEventListener("DOMContentLoaded", () => {
     })
     .catch(() => {
       // fallback seguro si AJAX falla
-      window.location.href = url;
+      formVaciar.submit();
     });
   });
 });

--- a/carrito/tests.py
+++ b/carrito/tests.py
@@ -1,3 +1,45 @@
 from django.test import TestCase
+from django.test import Client
+from django.urls import reverse
 
-# Create your tests here.
+from tienda.models import Producto
+
+
+class CarritoMetodoSeguroTests(TestCase):
+    def setUp(self):
+        self.producto = Producto.objects.create(
+            nombre="Dulce de prueba",
+            descripcion="Producto para pruebas del carrito",
+            precio="100.00",
+            disponible=True,
+        )
+        self.url_agregar = reverse(
+            "carrito:agregar_al_carrito",
+            kwargs={"producto_id": self.producto.id},
+        )
+
+    def test_get_no_agrega_producto_al_carrito(self):
+        response = self.client.get(self.url_agregar)
+
+        self.assertEqual(response.status_code, 405)
+        self.assertNotIn("carrito", self.client.session)
+
+    def test_post_agrega_producto_al_carrito(self):
+        response = self.client.post(
+            self.url_agregar,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        carrito = self.client.session["carrito"]
+        self.assertEqual(carrito[str(self.producto.id)]["cantidad"], 1)
+
+    def test_post_sin_csrf_es_rechazado_cuando_csrf_esta_activo(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+
+        response = csrf_client.post(
+            self.url_agregar,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/carrito/views.py
+++ b/carrito/views.py
@@ -1,7 +1,6 @@
 from django.http import JsonResponse
 from django.shortcuts import redirect, get_object_or_404, render
-from django.urls import reverse
-from pedidos.forms import PedidoClienteForm
+from django.views.decorators.http import require_POST
 from tienda.models import Producto
 from .carrito import Carrito
 
@@ -10,6 +9,7 @@ def es_ajax(request):
     return request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
 
+@require_POST
 def agregar_al_carrito(request, producto_id):
     carrito = Carrito(request)
     producto = get_object_or_404(Producto, id=producto_id)
@@ -21,6 +21,7 @@ def agregar_al_carrito(request, producto_id):
     # ✅ Volver a la misma URL desde donde se llamó
     return redirect(request.META.get("HTTP_REFERER", "carrito:ver_carrito"))
 
+@require_POST
 def restar_producto(request, producto_id):
     carrito = Carrito(request)
     producto = get_object_or_404(Producto, id=producto_id)
@@ -32,6 +33,7 @@ def restar_producto(request, producto_id):
     return redirect(request.META.get("HTTP_REFERER", "carrito:ver_carrito"))
 
 
+@require_POST
 def eliminar_producto(request, producto_id):
     carrito = Carrito(request)
     producto = get_object_or_404(Producto, id=producto_id)
@@ -44,6 +46,7 @@ def eliminar_producto(request, producto_id):
 
 
 
+@require_POST
 def limpiar_carrito(request):
     carrito = Carrito(request)
     carrito.limpiar()
@@ -51,7 +54,7 @@ def limpiar_carrito(request):
     if es_ajax(request):
         return JsonResponse({"ok": True})
 
-    return redirect("tienda:tienda")
+    return redirect("carrito:ver_carrito")
 
 
 def ver_carrito(request):

--- a/static/js/public_carrito.js
+++ b/static/js/public_carrito.js
@@ -9,10 +9,24 @@ window.DulceCayenaCarrito = (() => {
     setTimeout(() => t.remove(), 2500);
   }
 
+  function getCsrfToken() {
+    return window.DulceCayena?.getCsrfToken?.() || "";
+  }
+
   async function hit(url) {
     const res = await fetch(url, {
-      headers: { "X-Requested-With": "XMLHttpRequest" }
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "X-CSRFToken": getCsrfToken()
+      }
     });
+
+    if (!res.ok) {
+      throw new Error(`Error al actualizar carrito: ${res.status}`);
+    }
+
     window.dispatchEvent(new Event("carrito-actualizado"));
     return res;
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <title>{% block title %}Dulce Cayena{% endblock %}</title>
 
   <!-- Bootstrap y Fuentes -->
@@ -92,6 +93,13 @@
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
+  <script>
+    window.DulceCayena = window.DulceCayena || {};
+    window.DulceCayena.getCsrfToken = () => {
+      return document.querySelector('meta[name="csrf-token"]')?.content || "";
+    };
+  </script>
 
   <!-- ✅ Contador global del carrito -->
   <script>


### PR DESCRIPTION
## Resumen
- Cambia las acciones que modifican el carrito para aceptar solo POST.
- Envía CSRF token desde JavaScript en las acciones AJAX del carrito.
- Convierte controles del carrito/checkout a formularios POST.
- Agrega pruebas para evitar mutaciones por GET y validar protección CSRF.

## Verificación
- `python manage.py check`
- `python manage.py test carrito pedidos servicios`